### PR TITLE
A2 steps3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ build/
 
 ### Vagrant ###
 .vagrant/
+
+admin.conf

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,11 +9,16 @@ Vagrant.configure("2") do |config|
     # Control node configuration
     config.vm.define "ctrl" do |ctrl|
         ctrl.vm.provider "virtualbox" do |vb|
-            vb.memory = 4096
-            vb.cpus = 1
+            vb.memory = 4048
+            vb.cpus = 2
         end
         ctrl.vm.network "private_network", ip: "192.168.56.100"
         ctrl.vm.hostname = "ctrl"
+
+        #ctrl.vm.network "forwarded_port",
+        #    guest: 6443,
+        #    host: 6443,
+        #    host_ip: "192.168.56.100"
 
         ctrl.vm.provision "ansible" do |ansible|
             ansible.playbook = "ansible/ctrl.yml"

--- a/ansible/ctrl.yml
+++ b/ansible/ctrl.yml
@@ -3,5 +3,85 @@
 # Ansible playbook for control node
 - hosts: ctrl
   become: true
+  vars:
+    apiserver_addr: 192.168.56.100
+    pod_cidr: 10.244.0.0/16
+    ctrl_name: ctrl
+    kubeconfig_host_path: "../" # Hosts root project directry
+    kubeconfig_user_path: "/home/vagrant/.kube/config"
+    kubeconfig_src: "/etc/kubernetes/admin.conf"
+    flannel_version: "v0.26.7"
+    flannel_url: "https://raw.githubusercontent.com/flannel-io/flannel/{{ flannel_version }}/Documentation/kube-flannel.yml"
+    flannel_tmp: "/tmp/kube-flannel-{{ flannel_version }}.yml"
+    flannel_iface: "eth1"
+
   tasks:
     - import_tasks: general.yml
+
+    # Step 13
+    - name: Check for /etc/kubernetes/admin.conf
+      stat: 
+        path: /etc/kubernetes/admin.conf
+      register: admin_conf
+
+    - name: Initialize kubernetes iff admin.conf is absent
+      shell: |
+        kubeadm init \
+          --apiserver-advertise-address={{ apiserver_addr }} \
+          --node-name={{ ctrl_name }} \
+          --pod-network-cidr={{ pod_cidr }}
+      args:
+        creates: /etc/kubernetes/admin.conf
+      when: not admin_conf.stat.exists
+    
+    # Step 14
+    - name: Create .kube directory
+      file:
+        path: "{{ kubeconfig_user_path | dirname }}"
+        state: directory
+        owner: vagrant
+        group: vagrant
+        mode: '0755'
+    
+    - name: Copy admin.conf to vagrant user's .kube
+      copy:
+        src: "{{ kubeconfig_src }}"
+        dest: "{{ kubeconfig_user_path }}"
+        remote_src: true
+        owner: vagrant
+        group: vagrant
+        mode: '0644'
+
+    - name: Copy (fetch) admin.conf to host folder
+      fetch:
+        src: "{{ kubeconfig_src }}"
+        dest: "{{ kubeconfig_host_path }}"
+        flat: true
+        owner: root
+        group: root
+        mode: '0644'
+    
+    # Step 15
+    - name: Check if Flannel manifest is present
+      stat:
+        path: "{{ flannel_url }}"
+      register: flannel_pres
+
+    - name: Download Flannel manifest
+      get_url:
+        url: "{{ flannel_url }}"
+        dest: "{{ flannel_tmp }}"
+        mode: '0644'
+      when: not flannel_pres.stat.exists
+
+    - name: Inject --iface into Flannel DaemonSet args
+      ansible.builtin.replace:
+        path: "{{ flannel_tmp }}"
+        regexp: '^(\s*)- --ip-masq$'
+        replace: '\1- --ip-masq\n\1- --iface={{ flannel_iface }}'
+
+
+    - name: Apply Flannel network manifest
+      shell: >
+        kubectl apply -f {{ flannel_tmp }}
+        --kubeconfig {{ kubeconfig_src }}

--- a/ansible/ctrl.yml
+++ b/ansible/ctrl.yml
@@ -52,15 +52,13 @@
         group: vagrant
         mode: '0644'
 
-    - name: Copy (fetch) admin.conf to host folder
-      fetch:
+    - name: Publish admin.conf to host via /vagrant
+      copy:
         src: "{{ kubeconfig_src }}"
-        dest: "{{ kubeconfig_host_path }}"
-        flat: true
-        owner: root
-        group: root
+        dest: /vagrant/admin.conf
+        remote_src: true
         mode: '0644'
-    
+        
     # Step 15
     - name: Check if Flannel manifest is present
       stat:

--- a/ansible/general.yml
+++ b/ansible/general.yml
@@ -1,11 +1,9 @@
 # general.yml
 ---
 # General tasks for both ctrl and worker nodes
-- name: Disable Swap
-  shell:
-    cmd: swapoff -a
-  register: swapoff
-  changed_when: swapoff.rc == 0
+- name: Disable swap iff it's active
+  command: swapoff -a
+  when: ansible_swaptotal_mb > 0
 
 - name: Disable Swap in fstab
   lineinfile:
@@ -87,4 +85,47 @@
     - "kubeadm"
     - "kubelet"
     - "kubectl"
-   
+
+# Step 11
+- name: Create /etc/containerd directory
+  file: 
+    path: /etc/containerd
+    state: directory
+    owner: root
+    group: root
+    mode: '0644'
+
+- name: Generate default conterd config if missing
+  shell: containerd config default > /etc/containerd/config.toml
+  args:
+    creates: /etc/containerd/config.toml
+  
+- name: Disable AppArmor in containerD
+  lineinfile:
+    path: /etc/containerd/config.toml
+    regexp: '^\s*disable_apparmor\s*='
+    line: '    disable_apparmor = true'
+
+- name: Set sandbox_image to registry.k8s.io/pause:3.10
+  lineinfile:
+    path: /etc/containerd/config.toml
+    regexp: '^\s*sandbox_image\s*='
+    line: '    sandbox_image = "registry.k8s.io/pause:3.10"'
+
+- name: Enable SystemdCgroup for runc
+  lineinfile:
+    path: /etc/containerd/config.toml
+    regexp: '^\s*SystemdCgroup\s*='
+    line: '            SystemdCgroup = true'
+
+- name: Restart and enable containerd
+  service:
+    name: containerd
+    state: restarted
+    enabled: yes
+
+- name: Register kubelet for auto-start
+  service:
+    name: kubelet
+    state: started
+    enabled: yes


### PR DESCRIPTION
# Changes
- Configured containerd (step 11)
- Registered kubelet as autostart (step 12)
- Initialized cluster with kubeadm (step 13)
- Setup kubectl on ctrl vm and on host (see section about issues under)
- Applied flannel yml to create pod network

# Issues
Currently step 14, setting up kubectl on the host and the vm only works on the vm.
For example: ```vagrant ssh ctrl -c "kubectl get nodes"``` correctly reports the nodes in the cluster.
This same behaviour _should_ work on the host when running ```kubectl --kubeconfig=admin.conf get nodes```. This however does not work. Investigating showed that the ctrl ip on port 6443 is not accessable from the host at all (no service exposed on this port). This could either be due to some issue on my machine with kubectl or the admin.conf file copied in step 14 is incorrect in some way. This is a requirement from the assignment, so it should be investigated.