### PR TITLE
Kubernetes migration

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,3 @@
 MODEL_IMAGE=ghcr.io/remla25-team6/model-service:0.0.3-pre.20250506.194625
 APP_IMAGE=ghcr.io/remla25-team6/app:0.0.4-pre.20250506.183739
+MODEL_URL=http://model-service:8080

--- a/README.md
+++ b/README.md
@@ -4,17 +4,20 @@
 From the root directory:
 
 With docker:
-- `echo your_personal_access_token | docker login ghcr.io -u your_github_username --password-stdin` to login
-- `docker compose up` to start the application.
+- `echo your_personal_access_token | docker login ghcr.io -u your_github_username --password-stdin` - to login
+- `docker compose up` - to start the application
 - Access at: http://127.0.0.1:8080/
-- `docker compose down` to stop the application.
+- `docker compose down` - to stop the application
 
 With Kubernetes:
 - `vagrant up` - to start vagrant and provision
 - `ansible-playbook -u vagrant -i 192.168.56.100, finalization.yml` - to run final provisioning steps
 - `export $(cat .env | xargs)` - to set env variables (app/model images and model service URL)
 - `ansible-playbook -u vagrant -i 192.168.56.100, deployment.yml -e "MODEL_IMAGE=$MODEL_IMAGE APP_IMAGE=$APP_IMAGE MODEL_URL=$MODEL_URL"` - to apply the Kubernetes config
-
+- Access at: http://192.168.56.90:80/. Under some conditions the app may not be reachable at this IP, in that case:
+- `vagrant ssh ctrl` - to ssh into the control node
+- `kubectl get svc -n ingress-nginx` - and find the external IP you can access the app from
+- `vagrant halt` - to stop the application
 ## Repositories
 Below we list the repositories in our system, along with pointers to relevant files within each repository.
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,18 @@
 
 ## Starting the application
 From the root directory:
+
+With docker:
 - `echo your_personal_access_token | docker login ghcr.io -u your_github_username --password-stdin` to login
 - `docker compose up` to start the application.
 - Access at: http://127.0.0.1:8080/
 - `docker compose down` to stop the application.
+
+With Kubernetes:
+- `vagrant up` - to start vagrant and provision
+- `ansible-playbook -u vagrant -i 192.168.56.100, finalization.yml` - to run final provisioning steps
+- `export $(cat .env | xargs)` - to set env variables (app/model images and model service URL)
+- `ansible-playbook -u vagrant -i 192.168.56.100, deployment.yml -e "MODEL_IMAGE=$MODEL_IMAGE APP_IMAGE=$APP_IMAGE MODEL_URL=$MODEL_URL"` - to apply the Kubernetes config
 
 ## Repositories
 Below we list the repositories in our system, along with pointers to relevant files within each repository.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,7 @@
 # Vagrantfile
 WORKER_MEMORY = ENV.fetch("WORKER_MEM", 6144).to_i
 NUM_WORKERS = ENV.fetch("NUM_WORKERS", 2).to_i
+shared_folder_path = File.expand_path("./shared")
 
 Vagrant.configure("2") do |config|
     # Define the base box to use
@@ -15,6 +16,8 @@ Vagrant.configure("2") do |config|
         end
         ctrl.vm.network "private_network", ip: "192.168.56.100"
         ctrl.vm.hostname = "ctrl"
+        
+        ctrl.vm.synced_folder shared_folder_path, "/mnt/shared"
 
         #ctrl.vm.network "forwarded_port",
         #    guest: 6443,
@@ -38,6 +41,8 @@ Vagrant.configure("2") do |config|
             end
             node.vm.network "private_network", ip: "192.168.56.#{i + 100}"
             node.vm.hostname = "node-#{i}"
+
+            node.vm.synced_folder shared_folder_path, "/mnt/shared"
 
             node.vm.provision "ansible" do |ansible|
                 ansible.playbook = "ansible/node.yml"

--- a/deployment.yml
+++ b/deployment.yml
@@ -1,0 +1,25 @@
+- name: Deploy Kubernetes app
+  hosts: all
+  become: true
+  environment:
+    KUBECONFIG: /etc/kubernetes/admin.conf
+
+  tasks:
+    - name: Copy Kubernetes manifest to remote
+      copy:
+        src: kubernetes/sentiment.yml
+        dest: /tmp/sentiment.yml
+
+    - name: Kubernetes deployment
+      shell: kubectl apply -f /tmp/sentiment.yml
+      register: kubectl_apply_output
+      ignore_errors: yes
+
+    - name: Display the output of kubectl apply
+      debug:
+        var: kubectl_apply_output.stdout_lines
+
+    - name: Display the error output if apply fails
+      debug:
+        var: kubectl_apply_output.stderr_lines
+      when: kubectl_apply_output.stderr_lines is defined

--- a/deployment.yml
+++ b/deployment.yml
@@ -10,6 +10,11 @@
         src: kubernetes/sentiment.yml.j2
         dest: /tmp/sentiment.yml
 
+    - name: Create /mnt/shared directory
+      file:
+        path: /mnt/shared
+        state: directory
+
     - name: Kubernetes deployment
       shell: kubectl apply -f /tmp/sentiment.yml
       register: kubectl_apply_output

--- a/deployment.yml
+++ b/deployment.yml
@@ -5,9 +5,9 @@
     KUBECONFIG: /etc/kubernetes/admin.conf
 
   tasks:
-    - name: Copy Kubernetes manifest to remote
-      copy:
-        src: kubernetes/sentiment.yml
+    - name: Template Kubernetes setup file
+      template:
+        src: kubernetes/sentiment.yml.j2
         dest: /tmp/sentiment.yml
 
     - name: Kubernetes deployment

--- a/kubernetes/sentiment.yml
+++ b/kubernetes/sentiment.yml
@@ -1,0 +1,84 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: model-service-depl
+  labels:
+    app: model-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: model-service
+  template:
+    metadata:
+      labels:
+        app: model-service
+    spec:
+      containers:
+        - name: model-service
+          image: ghcr.io/remla25-team6/model-service:0.0.3-pre.20250506.194625
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: model-service
+spec:
+  selector:
+    app: model-service
+  ports:
+    - port: 8080
+      targetPort: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app-depl
+  labels:
+    app: app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      containers:
+        - name: app
+          image: ghcr.io/remla25-team6/app:0.0.4-pre.20250506.183739
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+          env:
+            - name: MODEL_URL
+              value: http://model-service:8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: app
+spec:
+  selector:
+    app: app
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: my-ingress
+spec:
+  ingressClassName: nginx
+  defaultBackend:
+    service:
+      name: app
+      port:
+        number: 80
+

--- a/kubernetes/sentiment.yml.j2
+++ b/kubernetes/sentiment.yml.j2
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: model-service
-          image: ghcr.io/remla25-team6/model-service:0.0.3-pre.20250506.194625
+          image: {{ MODEL_IMAGE }}
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
@@ -50,13 +50,16 @@ spec:
     spec:
       containers:
         - name: app
-          image: ghcr.io/remla25-team6/app:0.0.4-pre.20250506.183739
+          image: {{ APP_IMAGE }}
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
           env:
             - name: MODEL_URL
-              value: http://model-service:8080
+              valueFrom:
+                configMapKeyRef:
+                  name: configmap
+                  key: model.host
 ---
 apiVersion: v1
 kind: Service
@@ -81,4 +84,10 @@ spec:
       name: app
       port:
         number: 80
-
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: configmap
+data:
+  model.host: {{ MODEL_URL }}

--- a/kubernetes/sentiment.yml.j2
+++ b/kubernetes/sentiment.yml.j2
@@ -20,6 +20,13 @@ spec:
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
+          volumeMounts:
+            - mountPath: /mnt/shared
+              name: my-volume
+      volumes:
+        - name: my-volume
+          hostPath:
+            path: /mnt/shared/
 ---
 apiVersion: v1
 kind: Service
@@ -91,3 +98,10 @@ metadata:
   name: configmap
 data:
   model.host: {{ MODEL_URL }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-secret
+data:
+  foo: PGV4YW1wbGVfc2VjcmV0Pg==

--- a/shared/shared.txt
+++ b/shared/shared.txt
@@ -1,0 +1,1 @@
+This is a placeholder file to demonstrate shared storage in /mnt/shared.


### PR DESCRIPTION
This PR has all the steps for the migration from Docker to Kubernetes. The steps to run the application can be found in the README.md file, but I'll also put them here with extra useful commands. I have implemented all the steps up to and including the excellent criteria for migrating to Kubernetes (from how I understood them). I'm not sure about the criteria:
"- The model service can be relocated just by changing the Kubernetes config." If by config, it is referring to sentiment.yml file then I would think so but I don't entirely understand what they mean by relocate. If it's just changing which URL the model service is on then yes, but that seems obvious so I'm not sure.

To run application:
- `vagrant up` - to start vagrant and provision
- `ansible-playbook -u vagrant -i 192.168.56.100, finalization.yml` - to run final provisioning steps
- `export $(cat .env | xargs)` - to set env variables (app/model images and model service URL)
- `ansible-playbook -u vagrant -i 192.168.56.100, deployment.yml -e "MODEL_IMAGE=$MODEL_IMAGE APP_IMAGE=$APP_IMAGE MODEL_URL=$MODEL_URL"` - to apply the Kubernetes config
- Access at: http://192.168.56.90:80/. Under some conditions the app may not be reachable at this IP, in that case:
- `vagrant ssh ctrl` - to ssh into the control node
- `kubectl get svc -n ingress-nginx` - and find the external IP you can access the app from
- `vagrant halt` - to stop the application

Useful commands for verifying things:
 `kubectl get pods --all-namespaces` - see running pods
 ` kubectl get svc -n ingress-nginx ingress-nginx-controller` -  see external ingress IP, verify loadbalancer is running
 ` kubectl get svc` - verify services are running
 ` kubectl logs -n ingress-nginx deploy/ingress-nginx-controller` - see ingress logs, you shouldn't need this but it was useful for debugging