### PR TITLE
Deployment script improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,7 @@ Note that this automatically adds the following three entries to your ```/etc/ho
 192.168.56.93 grafana.local
 192.168.56.94 prometheus.local
 ```
-
-Note that port 443/TLS is used for these services.
+On each run the deployment script will prompt the user for the possibility of a cleanup. In case you are experiencing issues with the deployment script trying this cleanup step is recommended.
 #### B. Manual deployment with Ansible and raw Kubernetes manifests
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -71,9 +71,11 @@ chmod +x deploy-app.sh
 Note that this automatically adds the following three entries to your ```/etc/hosts``` file, if they are not already present:
 ```yaml
 192.168.56.91 dashboard.local
-192.168.56.92 grafana.local
-192.168.56.93 prometheus.local
+192.168.56.93 grafana.local
+192.168.56.94 prometheus.local
 ```
+
+Note that port 443/TLS is used for these services.
 #### B. Manual deployment with Ansible and raw Kubernetes manifests
 
 ```bash
@@ -118,7 +120,7 @@ After starting the application:
 ## Accessing Grafana Dashboard
 In order to import the dashboard in grafana and view the metrics open Grafana at:
 
-- http://grafana.local
+- http://grafana.local (or 192.168.56.93:443)
 
 Next, login using default credentials:
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,5 +1,5 @@
 # Vagrantfile
-WORKER_MEMORY = ENV.fetch("WORKER_MEM", 6000).to_i
+WORKER_MEMORY = ENV.fetch("WORKER_MEM", 3000).to_i
 NUM_WORKERS = ENV.fetch("NUM_WORKERS", 2).to_i
 shared_folder_path = File.expand_path("./shared")
 
@@ -7,6 +7,9 @@ Vagrant.configure("2") do |config|
     # Define the base box to use
     config.vm.box = "bento/ubuntu-24.04"
     config.ssh.forward_agent = true    # Enable ssh forward agent
+    config.vm.provider "virtualbox" do |vb|
+        vb.gui = false
+    end
 
     # Control node configuration
     config.vm.define "ctrl" do |ctrl|
@@ -36,8 +39,8 @@ Vagrant.configure("2") do |config|
     (1..NUM_WORKERS).each do |i|
         config.vm.define "node-#{i}" do |node|
             node.vm.provider "virtualbox" do |vb|
-                vb.memory = WORKER_MEMORY # Updated to 6144
-                vb.cpus = 2      # Updated to 2
+                vb.memory = WORKER_MEMORY 
+                vb.cpus = 2      
             end
             node.vm.network "private_network", ip: "192.168.56.#{i + 100}"
             node.vm.hostname = "node-#{i}"

--- a/ansible/general.yml
+++ b/ansible/general.yml
@@ -87,6 +87,8 @@
       - kubectl
     state: present
     install_recommends: no
+    update_cache: yes
+    cache_valid_time: 3600
 
 
 # A2: Step 11

--- a/finalization.yml
+++ b/finalization.yml
@@ -147,7 +147,8 @@
     - name: Add kubernetes-dashboard Helm repository
       kubernetes.core.helm_repository:
         name: kubernetes-dashboard
-        repo_url: https://kubernetes.github.io/dashboard/
+        repo_url: https://kubernetes.github.io/dashboard
+        state: present
 
     - name: Deploy Kubernetes Dashboard via Helm
       kubernetes.core.helm:
@@ -273,6 +274,14 @@
         - istio_namespace.resources | length == 0
           # Run if the namespace doesn't exist
 
+    - name: Create monitoring namespace
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: monitoring
 
     - name: Add Prometheus community Helm repository
       kubernetes.core.helm_repository: 
@@ -280,13 +289,40 @@
         repo_url: https://prometheus-community.github.io/helm-charts
         state: present
 
+    - name: Create TLS secret for Prometheus
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: prometheus-tls
+            namespace: monitoring
+          type: kubernetes.io/tls
+          data:
+            tls.crt: "{{ tls_cert.stdout | b64encode }}"
+            tls.key: "{{ tls_key.stdout | b64encode }}"
+    
+    - name: Create TLS secret for Grafana
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: grafana-tls
+            namespace: monitoring
+          type: kubernetes.io/tls
+          data:
+            tls.crt: "{{ tls_cert.stdout | b64encode }}"
+            tls.key: "{{ tls_key.stdout | b64encode }}"
+
     - name: Deploy kube-prometheus-stack
       kubernetes.core.helm:
         atomic: true
         name: prometheus-stack # DO NOT CHANGE THIS
         chart_ref: prometheus-community/kube-prometheus-stack
         release_namespace: monitoring
-        create_namespace: true 
         kubeconfig: "/etc/kubernetes/admin.conf"
         state: present 
         update_repo_cache: true
@@ -299,6 +335,31 @@
             enabled: true
             adminUser: admin           
             adminPassword: admin     
+            extraSecretMounts:
+              - name: grafana-tls
+                secretName: grafana-tls
+                mountPath: /cert
+                readOnly: true
+            livenessProbe:
+              httpGet:
+                path: /api/health
+                port: 3000
+                scheme: HTTPS
+            readinessProbe:
+              httpGet:
+                path: /api/health
+                port: 3000
+                scheme: HTTPS
+            startupProbe:
+              httpGet:
+                path: /api/health
+                port: 3000
+                scheme: HTTPS
+            grafana.ini:
+              server:
+                protocol: https
+                cert_file: /cert/tls.crt
+                cert_key: /cert/tls.key
             sidecar:
               dashboards:
                 enabled: true
@@ -307,18 +368,27 @@
             service:
               type: LoadBalancer
               loadBalancerIP: "192.168.56.93"
-              port: 80
+              port: 443 
 
           # Prometheus Configuration
           prometheus:
             enabled: true
             prometheusSpec:
+              web:
+                tlsConfig:
+                  cert:
+                    secret:
+                      name: prometheus-tls
+                      key: tls.crt
+                  keySecret:
+                    name: prometheus-tls
+                    key: tls.key
               serviceMonitorNamespaceSelector: {}
               serviceMonitorSelector: {}
             service:
               type: LoadBalancer
               loadBalancerIP: "192.168.56.94"
-              port: 80
+              port: 443
 
           alertmanager:
             enabled: false


### PR DESCRIPTION
#### Changes
- Modified the deployment script to provide the caller with the dashboard token (see #37)
- Properly enabled HTTPS and tls cert generation for prometheus/grafana (see #35 )
- Modified the deployment script to prompt the user to do a cleanup before trying to provision doing the following:
    - Destroy any previous VM's ```vagrant destroy -f```
    - Clear VM caches ```echo "3" | sudo tee /proc/sys/vm/drop_caches``` (Dramatically increases success rate on my machine)
    - Removing previous vbox host-only networks so new ones can be created by provisioning (this also increases stability on my machine)

#### How to test
1. Use the startup script to deploy the project
2. When deploying choose yes when prompted about cleanup step (to test stability of this step)
3. Verify that grafana/prometheus are accessible over HTTPS