### PR TITLE
Feature/cache model

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,4 @@
 MODEL_IMAGE=ghcr.io/remla25-team6/model-service:latest
 APP_IMAGE=ghcr.io/remla25-team6/app:latest
 MODEL_URL=http://model-service:8080
+ML_MODEL_VERSION=v0.1.0

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -9,8 +9,7 @@
     - After a stable release, main is set to a pre-release version that is higher than the latest release.
     - The released container images support multiple architectures, at least amd64 and arm64 .
     - The Dockerﬁle uses multiple stages, e.g., to reduce image size by avoiding apt cache in image.
-2. **Software reuse in libraries:** Good 🟡
-    - A local cache is used so the model is not just downloaded on every container start.
+2. **Software reuse in libraries:** Excellent ✅
 
 ### Containers and Orchestration
 1. **Exposing a model via REST:** Excellent ✅

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,7 +3,7 @@ has_vmware = Vagrant.has_plugin?("vagrant-vmware-desktop")
 
 # Choose box based on provider availability
 BOX = "bento/ubuntu-24.04"
-WORKER_MEMORY = ENV.fetch("WORKER_MEM", 2048).to_i
+WORKER_MEMORY = ENV.fetch("WORKER_MEM", 3000).to_i
 NUM_WORKERS = ENV.fetch("NUM_WORKERS", 2).to_i
 shared_folder_path = File.expand_path("./shared")
 
@@ -49,7 +49,7 @@ Vagrant.configure("2") do |config|
     ctrl.vm.network "private_network", ip: "192.168.56.100"
     ctrl.vm.hostname = "ctrl"
 
-    # ctrl.vm.synced_folder shared_folder_path, "/mnt/shared"
+    ctrl.vm.synced_folder shared_folder_path, "/mnt/shared"
 
     ctrl.vm.provision "ansible" do |ansible|
       ansible.playbook = "ansible/ctrl.yml"
@@ -77,7 +77,7 @@ Vagrant.configure("2") do |config|
       node.vm.network "private_network", ip: "192.168.56.#{i + 100}"
       node.vm.hostname = "node-#{i}"
 
-      # node.vm.synced_folder shared_folder_path, "/mnt/shared"
+      node.vm.synced_folder shared_folder_path, "/mnt/shared"
 
       node.vm.provision "ansible" do |ansible|
         ansible.playbook = "ansible/node.yml"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
   services:
     model_service:
       image: ${MODEL_IMAGE}
+      environment:
+        - ML_MODEL_VERSION=${ML_MODEL_VERSION}
       container_name: model-service
       restart: unless-stopped
       volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,6 @@
   services:
     model_service:
       image: ${MODEL_IMAGE}
-      platform: linux/amd64
-      ports:
-        - ":8080"
       container_name: model-service
       restart: unless-stopped
       volumes:
@@ -13,7 +10,6 @@
 
     app:
       image: ${APP_IMAGE}
-      platform: linux/amd64
       ports:
         - "8080:8080"
       environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@
       container_name: model-service
       restart: unless-stopped
       volumes:
-        - ./model:/app/folder
+        - model_cache:/app/model_cache
       secrets:
         - example_secret
 
@@ -22,11 +22,12 @@
         - model_service
       container_name: app
       restart: unless-stopped
-      volumes:
-        - ./model:/app/folder
       secrets:
         - example_secret
 
   secrets:
     example_secret:
       file: ./secrets/example_secret.txt
+
+  volumes:
+    model_cache:

--- a/sentiment-chart/templates/model-deployment.yaml
+++ b/sentiment-chart/templates/model-deployment.yaml
@@ -24,12 +24,12 @@ spec:
           ports:
             - containerPort: 8080
           volumeMounts:
-            - mountPath: /mnt/shared
-              name: my-volume
+            - mountPath: /app/model_cache
+              name: model-cache-volume
       volumes:
-        - name: my-volume
+        - name: model-cache-volume
           hostPath:
-            path: {{ .Values.sharedVolume.path }}
+            path: {{ .Values.modelCacheVolume.path }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -57,9 +57,9 @@ spec:
           ports:
             - containerPort: 8080
           volumeMounts:
-            - mountPath: /mnt/shared
-              name: my-volume
+            - mountPath: /app/model_cache
+              name: model-cache-volume
       volumes:
-        - name: my-volume
+        - name: model-cache-volume
           hostPath:
-            path: {{ .Values.sharedVolume.path }}
+            path: {{ .Values.modelCacheVolume.path }}

--- a/sentiment-chart/templates/model-deployment.yaml
+++ b/sentiment-chart/templates/model-deployment.yaml
@@ -20,6 +20,9 @@ spec:
       containers:
         - name: model-service
           image: {{ .Values.model.image }}
+          env:
+            - name: ML_MODEL_VERSION
+              value: {{ .Values.model.mlModelVersion }}
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
@@ -53,6 +56,9 @@ spec:
       containers:
         - name: model-service
           image: {{ .Values.model.image2 }}
+          env:
+            - name: ML_MODEL_VERSION
+              value: {{ .Values.model.mlModelVersion2 }}
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080

--- a/sentiment-chart/values.yaml
+++ b/sentiment-chart/values.yaml
@@ -2,6 +2,8 @@ model:
   image: ghcr.io/remla25-team6/model-service:latest
   image2: ghcr.io/remla25-team6/model-service:latest
   host: model-service:8080
+  mlModelVersion: "v0.1.0"
+  mlModelVersion2: "v0.1.0"
 
 app:
   image: ghcr.io/remla25-team6/app:latest

--- a/sentiment-chart/values.yaml
+++ b/sentiment-chart/values.yaml
@@ -19,7 +19,7 @@ metrics:
 secret:
   foo: PGV4YW1wbGVfc2VjcmV0Pg==
 
-sharedVolume:
+modelCacheVolume:
   path: /mnt/shared
 
 


### PR DESCRIPTION
This PR is linked to the PR in model-service: https://github.com/remla25-team6/model-service/pull/10
They should be reviewed and approved together.

Together they complete the criteria:
### Software Reuse in Libraries:
- The model is not part of the container image, i.e., it can be updated without creating a new image
by refering to a specific model version that is downloaded on-start.
- A local cache is used so the model is not just downloaded on every container start. 

The model is now cached using volumes for both the Docker install and the Helm install. The model is not inside the image anymore, but is downloaded (or cache is used) on start. 

To test it works:
For docker, follow the docker compose up steps from operation (itll automatically pull the new image on model-service which uses the caching). Upon the second run of docker compose up you should see in the model-service logs that the cached model was used.

For helm, run the deploy script. First, you will be able to observe the model goes into the shared/ folder and is shared for all VMs and mounted as the cache for the model-service deployments. Secondly you can use `kubectl logs <model-service-pod-name>` and once again observe that on the second time of running the pods, the cached model will be used. `vagrant reload` can be used to reload the pods. 

I had lots of memory issues deploying the entire app at this point. My PC just couldnt handle it. I couldnt have a single thing open in the background, so I hope it goes better for you...



Closes #3, closes #15 