### PR TITLE
Allow Changing Model Service Name From values.yaml

### DIFF
--- a/sentiment-chart/templates/model-deployment.yaml
+++ b/sentiment-chart/templates/model-deployment.yaml
@@ -1,20 +1,20 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-model-service-v1
+  name: {{ .Release.Name }}-{{ .Values.model.serviceName }}-v1
   labels:
-    app: {{ .Release.Name }}-model-service
+    app: {{ .Release.Name }}-{{ .Values.model.serviceName }}
     version: v1
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: {{ .Release.Name }}-model-service
+      app: {{ .Release.Name }}-{{ .Values.model.serviceName }}
       version: v1
   template:
     metadata:
       labels:
-        app: {{ .Release.Name }}-model-service
+        app: {{ .Release.Name }}-{{ .Values.model.serviceName }}
         version: v1
     spec:
       containers:
@@ -37,20 +37,20 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-model-service-v2
+  name: {{ .Release.Name }}-{{ .Values.model.serviceName }}-v2
   labels:
-    app: {{ .Release.Name }}-model-service
+    app: {{ .Release.Name }}-{{ .Values.model.serviceName }}
     version: v2
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: {{ .Release.Name }}-model-service
+      app: {{ .Release.Name }}-{{ .Values.model.serviceName }}
       version: v2
   template:
     metadata:
       labels:
-        app: {{ .Release.Name }}-model-service
+        app: {{ .Release.Name }}-{{ .Values.model.serviceName }}
         version: v2
     spec:
       containers:

--- a/sentiment-chart/templates/model-service-destinationrule.yaml
+++ b/sentiment-chart/templates/model-service-destinationrule.yaml
@@ -1,9 +1,9 @@
 apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule
 metadata:
-  name: {{ .Release.Name }}-model-service-dr
+  name: {{ .Release.Name }}-{{ .Values.model.serviceName }}-dr
 spec:
-  host: {{ .Release.Name }}-model-service
+  host: {{ .Release.Name }}-{{ .Values.model.serviceName }}
   subsets:
     - name: v1
       labels:

--- a/sentiment-chart/templates/model-service-virtualservice.yaml
+++ b/sentiment-chart/templates/model-service-virtualservice.yaml
@@ -2,19 +2,19 @@
 apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
-  name: {{ .Release.Name }}-model-service-vs
+  name: {{ .Release.Name }}-{{ .Values.model.serviceName }}-vs
 spec:
   hosts:
-    - {{ .Release.Name }}-model-service
+    - {{ .Release.Name }}-{{ .Values.model.serviceName }}
   http:
     - match:
         - sourceLabels:
             version: v2
       route:
         - destination:
-            host: {{ .Release.Name }}-model-service
+            host: {{ .Release.Name }}-{{ .Values.model.serviceName }}
             subset: v2
     - route:
         - destination:
-            host: {{ .Release.Name }}-model-service
+            host: {{ .Release.Name }}-{{ .Values.model.serviceName }}
             subset: v1

--- a/sentiment-chart/templates/model-service.yaml
+++ b/sentiment-chart/templates/model-service.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-model-service
+  name: {{ .Release.Name }}-{{ .Values.model.serviceName }}
 spec:
   selector:
-    app: {{ .Release.Name }}-model-service
+    app: {{ .Release.Name }}-{{ .Values.model.serviceName }}
   ports:
     - port: 8080
       targetPort: 8080

--- a/sentiment-chart/templates/ratelimit-envoyfilter.yaml
+++ b/sentiment-chart/templates/ratelimit-envoyfilter.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   workloadSelector:
     labels:
-      app: {{ .Release.Name }}-model-service
+      app: {{ .Release.Name }}-{{ .Values.model.serviceName }}
   configPatches:
   - applyTo: HTTP_FILTER
     match:

--- a/sentiment-chart/values.yaml
+++ b/sentiment-chart/values.yaml
@@ -4,6 +4,7 @@ model:
   host: model-service:8080
   mlModelVersion: "v0.1.0"
   mlModelVersion2: "v0.1.0"
+  serviceName: model-service
 
 app:
   image: ghcr.io/remla25-team6/app:0.1.1


### PR DESCRIPTION
Adjusted Helm charts to allow changing the (DNS) service name from the values.yaml file. This is currently untested due to local machine issues, but @MaartenVladimir has agreed to test this pre-merge.